### PR TITLE
Added new function Lighting.getCanvas()

### DIFF
--- a/src/illuminated.js
+++ b/src/illuminated.js
@@ -1131,6 +1131,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   cp.Lighting.prototype.render = function (ctx) {
     ctx.drawImage(this._cache.canvas, 0, 0);
   }
+  
+  /**
+  Returns the light and shadows onto the given context as canvas.
+  @method render
+  @return {Canvas} The picture of the light and shadow.
+  **/
+  cp.Lighting.prototype.getCanvas = function () {
+    return this._cache.canvas;
+  }
 
   /**
   Defines the dark layer which hides the dark area not illuminated by a set of


### PR DESCRIPTION
The new function Lighting.getCanvas() returns the rendered canvas object. This is necessary when you want to use this framework with an WebGl renderer which don't work with the canvas and gtx objects (For example PIXI).

I personally use this function for my new game, which is realized with the WebGl render from PIXI. I hope to help other people with this little hack.
